### PR TITLE
Add testing infrastructure to run all tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,7 @@ jobs:
         run: |
           rm -rf build/ || true # nuke build folder
           lake build # run build
+
+      - name: Test parser
+        run: |
+          ./build/bin/CParser Tests/**/*.c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Test parser
         run: |
-          ./build/bin/CParser Tests/**/*.c
+          find ./Tests/ -name '*.c' | xargs ./build/bin/CParser

--- a/Main.lean
+++ b/Main.lean
@@ -1,17 +1,16 @@
 import Lean
 import CParser
 
+open Lean
 
-def default_filename := "Tests/primary_expression.c"
-
-def main (args : List String): IO Unit := do
-  let filename := match args.get? 0 with
-    | some fn => fn
-    | none => default_filename
-  let lines <- IO.FS.lines filename
+-- Check that a file parses correctly.
+-- TODO: collect the information into a struct, which
+-- prints the information at the end as a CSV.
+def check_file (filepath: String): IO Unit := do
+  let lines <- IO.FS.lines filepath
   let preprocessed := preprocess lines
   let fileStr := preprocessed.foldl (λ s₁ s₂ => s₁ ++ "\n" ++ s₂) ""
-  println! s!"parsing {filename}: \n {fileStr}"
+  println! s!"parsing {filepath}: \n {fileStr}"
   -- let pipeline := Lean.quote [file]
   Lean.initSearchPath (← Lean.findSysroot) ["build/lib"]
   let env ← Lean.importModules [{ module := `CParser }] {}
@@ -21,3 +20,9 @@ def main (args : List String): IO Unit := do
     | none => s!"parse ok! parsed: \n---\n{parsed.2}\n---\n"
   println! res_str
   return ()
+
+-- treat each argument as a filepath, and then run the syntax check.
+def main (args : List String): IO Unit := do
+  let filepaths := args
+  for path in filepaths do
+    check_file path

--- a/Main.lean
+++ b/Main.lean
@@ -1,28 +1,62 @@
 import Lean
 import CParser
+import CParser.AST.GroupOne
+import CParser.AST.GroupTwo
 
-open Lean
+open IO
+open IO.FS
+open System
 
--- Check that a file parses correctly.
--- TODO: collect the information into a struct, which
--- prints the information at the end as a CSV.
-def check_file (filepath: String): IO Unit := do
+
+abbrev Checker := (String → Lean.Environment → Option String)
+
+def directory_checker_map : List (FilePath × Checker) := 
+ [(FilePath.mk "./Tests/GroupOne/AddExpr/", fun str env => (parseAddExpression str env).fst)
+ ,(FilePath.mk "./Tests/GroupOne/AndExpr/", fun str env => (parseAndExpression str env).fst)
+ ,(FilePath.mk "./Tests/GroupOne/AssmtOp/", fun str env => (parseAssmtOperator str env).fst)
+ ]
+
+inductive TestResult
+| Success
+| Failure
+
+def TestResult.and: TestResult → TestResult → TestResult 
+| Success,  Success => Success
+| _, _ => Failure
+
+def TestResult.success? : TestResult -> Bool
+| Success => true
+| Failure => false
+
+-- Run the checker, output CSV formatted info about parse
+-- success / failure
+def checkFileParse (filepath: FilePath) (checker: Checker) : IO TestResult := do
   let lines <- IO.FS.lines filepath
   let preprocessed := preprocess lines
   let fileStr := preprocessed.foldl (λ s₁ s₂ => s₁ ++ "\n" ++ s₂) ""
-  println! s!"parsing {filepath}: \n {fileStr}"
   -- let pipeline := Lean.quote [file]
   Lean.initSearchPath (← Lean.findSysroot) ["build/lib"]
   let env ← Lean.importModules [{ module := `CParser }] {}
-  let parsed := parse fileStr env
-  let res_str := match parsed.1 with
-    | some msg => "syntax error:\n" ++ msg
-    | none => s!"parse ok! parsed: \n---\n{parsed.2}\n---\n"
-  println! res_str
-  return ()
+  match checker fileStr env with
+    | some msg => do 
+       IO.println $ s!"{filepath}, error, {msg}"
+       return TestResult.Failure
+    | none => do
+      IO.println $ s!"{filepath}, ok, "
+      return TestResult.Success
 
--- treat each argument as a filepath, and then run the syntax check.
-def main (args : List String): IO Unit := do
-  let filepaths := args
-  for path in filepaths do
-    check_file path
+def runTestHarness: IO UInt32 := do
+  let isFile (p: FilePath) : IO Bool := do
+      return (<- p.metadata).type == FileType.file
+
+  let mut returnValue := TestResult.Success
+  for (dir_path, checker) in directory_checker_map do
+    let paths <- dir_path.walkDir -- walk the directory
+    let paths <- paths.filterM isFile -- keep only files
+    let results <- paths.mapM (checkFileParse (checker := checker))
+    let result := results.foldl (f := TestResult.and) (init := .Success)
+    returnValue := TestResult.and result returnValue
+  return (if returnValue.success? then 0 else 1)
+ 
+
+def main: IO UInt32 := runTestHarness


### PR DESCRIPTION
We change our executable to accept each command line
argument as a separate file path that is to be tested.

We currently simply run each file. Eventually, we shall collect
statistics, and perhaps even run these tests in parallel with Lean's
`Task` infrastructure.