### PR TITLE
modify initializer list grammar for Lean

### DIFF
--- a/CParser/AST/ClassDec.lean
+++ b/CParser/AST/ClassDec.lean
@@ -33,7 +33,7 @@ instance : Inhabited TypeQualList where default := TypeQualList.TypeQual (defaul
 instance : Inhabited Pointer where default := Pointer.StarTypeQualList (default : TypeQualList)
 instance : Inhabited Declarator where default := Declarator.DirDecl (default : DirDecl)
 instance : Inhabited Initializer where default := Initializer.AssmtExpr (default : AssmtExpr)
-instance : Inhabited InitList where default := InitList.Init (default : Initializer)
+instance : Inhabited InitList where default := InitList.InitList []
 instance : Inhabited InitDecl where default := InitDecl.Declarator (default : Declarator)
 
 mutual
@@ -203,8 +203,7 @@ partial def declaratorToString : Declarator → String
   | .DirDecl d => (dirDeclToString d)
 
 partial def initListToString : InitList → String
-  | .Init i => (initializerToString i)
-  | .InitListInit il i => (initListToString il) ++ " , " ++ (initializerToString i)
+  | .InitList inits => ", ".intercalate (inits.map initializerToString)
 
 partial def initializerToString : Initializer → String
   | .AssmtExpr a => (assmtExprToString a)

--- a/CParser/AST/GroupTwo.lean
+++ b/CParser/AST/GroupTwo.lean
@@ -54,8 +54,7 @@ inductive Declarator where
   | DirDecl : DirDecl → Declarator
 
 inductive InitList where
-  | Init : Initializer → InitList
-  | InitListInit : InitList → Initializer → InitList
+  | InitList : List Initializer → InitList
 
 inductive Initializer where
   | AssmtExpr : AssmtExpr → Initializer

--- a/CParser/Parser/MakeFuncs.lean
+++ b/CParser/Parser/MakeFuncs.lean
@@ -217,9 +217,8 @@ partial def mkInitList : Lean.Syntax → Except String InitList
 
 
 partial def mkInitializer : Lean.Syntax → Except String Initializer
---   | `(initializer| $a:assignment_expression) => Initializer.AssmtExpr <$> (mkAssmtExpression a)
+  | `(initializer| $a:assignment_expression) => Initializer.AssmtExpr <$> (mkAssmtExpression a)
   | `(initializer| { $i:initializer_list }) => Initializer.InitListCurl <$> (mkInitList i)
---  | `(initializer| { $i:initializer_list , } ) => Initializer.InitListCurlComma <$> (mkInitList i)
   | _ => throw "unexpected syntax"
 
 partial def mkInitDecl : Lean.Syntax → Except String InitDecl

--- a/CParser/Syntax/GroupTwo.lean
+++ b/CParser/Syntax/GroupTwo.lean
@@ -100,7 +100,8 @@ Change to grammar:
 We use Lean4's higher level `sepBy` to create a parser.
 -/
 
-syntax sepBy(assignment_expression, "," , ",", allowTrailingSep) : initializer_list
+syntax sepBy(initializer, "," , ",", allowTrailingSep) : initializer_list
+syntax assignment_expression : initializer
 syntax "{" initializer_list "}" : initializer
 syntax "`[initializer| " initializer "]" : term
 

--- a/CParser/Syntax/GroupTwo.lean
+++ b/CParser/Syntax/GroupTwo.lean
@@ -1,6 +1,14 @@
 import CParser.SyntaxDecl
 import CParser.AST
+import CParser.AST.GroupOne
+import CParser.Syntax.GroupOne
+import Lean
+
 open AST
+open Lean -- for (sepBy ...)
+open Lean.Parser -- for (sepBy ...)
+open Lean.Elab
+open Lean.Elab.Command
 
 syntax conditional_expression : constant_expression
 
@@ -61,6 +69,9 @@ syntax direct_declarator : declarator
 
 syntax "`[declarator| " declarator "]" : term
 
+/-
+Original:
+--------
 syntax initializer : initializer_list
 syntax initializer_list "," initializer : initializer_list
 
@@ -70,9 +81,36 @@ syntax assignment_expression : initializer
 syntax "{" initializer_list "}" : initializer
 syntax "{" initializer_list "," "}" : initializer
 
+Reformat:
+---------
+Consider `init_declarator_2.c`:
+foo(bar, bat, baz) = {i = 5, j = 6 | 2, }
+
+The right-hand-size { i = 5, j = 6 | 2   , } should be parsed as:
+initializer ->      { initializer_list  ","} 
+
+However, the Lean parser parses this as:
+                    { i = 5, j = 6 | 2    ,                  }
+initializer      -> { initializer_list                       } 
+initializer_list -> { initializer_list    , initializer      }
+                                            ^^^^^^^^^^^
+
+Change to grammar:
+------------------
+We use Lean4's higher level `sepBy` to create a parser.
+-/
+
+syntax sepBy(assignment_expression, "," , ",", allowTrailingSep) : initializer_list
+syntax "{" initializer_list "}" : initializer
 syntax "`[initializer| " initializer "]" : term
 
+/-
+Original:
+---------
 syntax declarator : init_declarator
 syntax declarator "=" initializer : init_declarator
+-/
 
+syntax declarator ("=" initializer)? : init_declarator
 syntax "`[init_declarator| " init_declarator "]" : term
+


### PR DESCRIPTION
Lean wants the grammar to be unambiguous, so we massage the
grammar to make it transparent to Lean.

This does not yet work, because my massaging of the grammar is incorrect. 

Closes #3 