### PR TITLE
Refactor: Use Except to represent parse error.

### DIFF
--- a/CParser/Parser/ParseFuncs.lean
+++ b/CParser/Parser/ParseFuncs.lean
@@ -7,193 +7,193 @@ open AST
 
 
 -- Parse a primary expression into 
-def parsePrimaryExpression : String → Lean.Environment → Option String × PrimaryExpr := 
+def parsePrimaryExpression : String → Lean.Environment → Except ParseError PrimaryExpr := 
   mkNonTerminalParser `primary_expression mkPrimaryExpression
 
-def parsePostfixExpression : String → Lean.Environment → Option String × PostfixExpr :=
+def parsePostfixExpression : String → Lean.Environment → Except ParseError PostfixExpr :=
   mkNonTerminalParser `postfix_expression mkPostfixExpression
 
-def parseUnaryOperator : String → Lean.Environment → Option String × UnaryOp :=
+def parseUnaryOperator : String → Lean.Environment → Except ParseError UnaryOp :=
   mkNonTerminalParser `unary_operator mkUnaryOperator
 
-def parseUnaryExpression : String → Lean.Environment → Option String × UnaryExpr :=
+def parseUnaryExpression : String → Lean.Environment → Except ParseError UnaryExpr :=
   mkNonTerminalParser `unary_expression mkUnaryExpression
 
-def parseCastExpression : String → Lean.Environment → Option String × CastExpr :=
+def parseCastExpression : String → Lean.Environment → Except ParseError CastExpr :=
   mkNonTerminalParser `cast_expression mkCastExpression
 
-def parseMultExpression : String → Lean.Environment → Option String × MultExpr :=
+def parseMultExpression : String → Lean.Environment → Except ParseError MultExpr :=
   mkNonTerminalParser `multiplicative_expression mkMultExpression
 
-def parseAddExpression : String → Lean.Environment → Option String × AddExpr :=
+def parseAddExpression : String → Lean.Environment → Except ParseError AddExpr :=
   mkNonTerminalParser `additive_expression mkAddExpression
 
-def parseShiftExpression : String → Lean.Environment → Option String × ShiftExpr :=
+def parseShiftExpression : String → Lean.Environment → Except ParseError ShiftExpr :=
   mkNonTerminalParser `shift_expression mkShiftExpression
 
-def parseRelExpression : String → Lean.Environment → Option String × RelExpr :=
+def parseRelExpression : String → Lean.Environment → Except ParseError RelExpr :=
   mkNonTerminalParser `relational_expression mkRelExpression
 
-def parseEqExpression : String → Lean.Environment → Option String × EqExpr :=
+def parseEqExpression : String → Lean.Environment → Except ParseError EqExpr :=
   mkNonTerminalParser `equality_expression mkEqExpression
 
-def parseAndExpression : String → Lean.Environment → Option String × AndExpr :=
+def parseAndExpression : String → Lean.Environment → Except ParseError AndExpr :=
   mkNonTerminalParser `and_expression mkAndExpression
 
-def parseXOrExpression : String → Lean.Environment → Option String × XOrExpr :=
+def parseXOrExpression : String → Lean.Environment → Except ParseError XOrExpr :=
   mkNonTerminalParser `exclusive_or_expression mkXOrExpression
 
-def parseIOrExpression : String → Lean.Environment → Option String × IOrExpr :=
+def parseIOrExpression : String → Lean.Environment → Except ParseError IOrExpr :=
   mkNonTerminalParser `inclusive_or_expression mkIOrExpression
 
-def parseLAndExpression : String → Lean.Environment → Option String × LAndExpr :=
+def parseLAndExpression : String → Lean.Environment → Except ParseError LAndExpr :=
   mkNonTerminalParser `logical_and_expression mkLAndExpression
 
-def parseLOrExpression : String → Lean.Environment → Option String × LOrExpr :=
+def parseLOrExpression : String → Lean.Environment → Except ParseError LOrExpr :=
   mkNonTerminalParser `logical_or_expression mkLOrExpression
 
-def parseCondExpression : String → Lean.Environment → Option String × CondExpr :=
+def parseCondExpression : String → Lean.Environment → Except ParseError CondExpr :=
   mkNonTerminalParser `conditional_expression mkCondExpression
 
-def parseAssmtOperator : String → Lean.Environment → Option String × AssmtOp :=
+def parseAssmtOperator : String → Lean.Environment → Except ParseError AssmtOp :=
   mkNonTerminalParser `assignment_operator mkAssmtOperator
 
-def parseAssmtExpression : String → Lean.Environment → Option String × AssmtExpr :=
+def parseAssmtExpression : String → Lean.Environment → Except ParseError AssmtExpr :=
   mkNonTerminalParser `assignment_expression mkAssmtExpression
 
-def parseArgExprList : String → Lean.Environment → Option String × ArgExprList :=
+def parseArgExprList : String → Lean.Environment → Except ParseError ArgExprList :=
   mkNonTerminalParser `argument_expression_list mkArgExprList
 
-def parseExpression : String → Lean.Environment → Option String × Expression :=
+def parseExpression : String → Lean.Environment → Except ParseError Expression :=
   mkNonTerminalParser `expression mkExpression
 
-def parseConstantExpression : String → Lean.Environment → Option String × ConstantExpr := 
+def parseConstantExpression : String → Lean.Environment → Except ParseError ConstantExpr := 
   mkNonTerminalParser `constant_expression mkConstExpr
 
-def parseDirAbstrDecl : String → Lean.Environment → Option String × DirAbstrDecl := 
+def parseDirAbstrDecl : String → Lean.Environment → Except ParseError DirAbstrDecl := 
   mkNonTerminalParser `direct_abstract_declarator mkDirAbstrDecl
 
-def parseAbstrDecl : String → Lean.Environment → Option String × AbstrDecl := 
+def parseAbstrDecl : String → Lean.Environment → Except ParseError AbstrDecl := 
   mkNonTerminalParser `abstract_declarator mkAbstrDecl
 
-def parseIdentList : String → Lean.Environment → Option String × IdentList := 
+def parseIdentList : String → Lean.Environment → Except ParseError IdentList := 
   mkNonTerminalParser `identifier_list mkIdentList
 
-def parseDirDecl : String → Lean.Environment → Option String × DirDecl := 
+def parseDirDecl : String → Lean.Environment → Except ParseError DirDecl := 
   mkNonTerminalParser `direct_declarator mkDirDecl
 
-def parseTypeQualList : String → Lean.Environment → Option String × TypeQualList := 
+def parseTypeQualList : String → Lean.Environment → Except ParseError TypeQualList := 
   mkNonTerminalParser `type_qualifier_list mkTypeQualList
 
-def parseTypeQual : String → Lean.Environment → Option String × TypeQual := 
+def parseTypeQual : String → Lean.Environment → Except ParseError TypeQual := 
   mkNonTerminalParser `type_qualifier mkTypeQual
 
-def parsePointer : String → Lean.Environment → Option String × Pointer :=
+def parsePointer : String → Lean.Environment → Except ParseError Pointer :=
   mkNonTerminalParser `pointer mkPointer
 
-def parseDeclarator : String → Lean.Environment → Option String × Declarator := 
+def parseDeclarator : String → Lean.Environment → Except ParseError Declarator := 
   mkNonTerminalParser `declarator mkDeclarator
 
-def parseInitList : String → Lean.Environment → Option String × InitList :=
+def parseInitList : String → Lean.Environment → Except ParseError InitList :=
   mkNonTerminalParser `initializer_list mkInitList
 
-def parseInitializer : String → Lean.Environment → Option String × Initializer := 
+def parseInitializer : String → Lean.Environment → Except ParseError Initializer := 
   mkNonTerminalParser `initializer mkInitializer
 
-def parseInitDecl : String → Lean.Environment → Option String × InitDecl := 
+def parseInitDecl : String → Lean.Environment → Except ParseError InitDecl := 
   mkNonTerminalParser `init_declarator mkInitDecl
 
-def parseDeclaration : String → Lean.Environment → Option String × Declaration := 
+def parseDeclaration : String → Lean.Environment → Except ParseError Declaration := 
   mkNonTerminalParser `declaration mkDeclaration
 
-def parseDeclList : String → Lean.Environment → Option String × DeclList := 
+def parseDeclList : String → Lean.Environment → Except ParseError DeclList := 
   mkNonTerminalParser `declaration_list mkDeclList
 
-def parseDeclSpec : String → Lean.Environment → Option String × DeclSpec := 
+def parseDeclSpec : String → Lean.Environment → Except ParseError DeclSpec := 
   mkNonTerminalParser `declaration_specifiers mkDeclSpec
 
-def parseEnumerator : String → Lean.Environment → Option String × Enumerator := 
+def parseEnumerator : String → Lean.Environment → Except ParseError Enumerator := 
   mkNonTerminalParser `enumerator mkEnumerator
 
-def parseEnumList : String → Lean.Environment → Option String × EnumList := 
+def parseEnumList : String → Lean.Environment → Except ParseError EnumList := 
   mkNonTerminalParser `enumerator_list mkEnumList
 
-def parseEnumSpec : String → Lean.Environment → Option String × EnumSpec := 
+def parseEnumSpec : String → Lean.Environment → Except ParseError EnumSpec := 
   mkNonTerminalParser `enum_specifier mkEnumSpec
 
-def parseInitDeclList : String → Lean.Environment → Option String × InitDeclList := 
+def parseInitDeclList : String → Lean.Environment → Except ParseError InitDeclList := 
   mkNonTerminalParser `init_declarator_list mkInitDeclList
 
-def parseParamDecl : String → Lean.Environment → Option String × ParamDecl := 
+def parseParamDecl : String → Lean.Environment → Except ParseError ParamDecl := 
   mkNonTerminalParser `parameter_declaration mkParamDecl
 
-def parseParamList : String → Lean.Environment → Option String × ParamList := 
+def parseParamList : String → Lean.Environment → Except ParseError ParamList := 
   mkNonTerminalParser `parameter_list mkParamList
 
-def parseParamTypeList : String → Lean.Environment → Option String × ParamTypeList := 
+def parseParamTypeList : String → Lean.Environment → Except ParseError ParamTypeList := 
   mkNonTerminalParser `parameter_type_list mkParamTypeList
 
-def parseSpecQualList : String → Lean.Environment → Option String × SpecQualList := 
+def parseSpecQualList : String → Lean.Environment → Except ParseError SpecQualList := 
   mkNonTerminalParser `specifier_qualifier_list mkSpecQualList
 
-def parseStorClassSpec : String → Lean.Environment → Option String × StorClassSpec := 
+def parseStorClassSpec : String → Lean.Environment → Except ParseError StorClassSpec := 
   mkNonTerminalParser `storage_class_specifier mkStorClassSpec
 
-def parseStructDecl : String → Lean.Environment → Option String × StructDecl := 
+def parseStructDecl : String → Lean.Environment → Except ParseError StructDecl := 
   mkNonTerminalParser `struct_declarator mkStructDecl
 
-def parseStructDeclaration : String → Lean.Environment → Option String × StructDeclaration := 
+def parseStructDeclaration : String → Lean.Environment → Except ParseError StructDeclaration := 
   mkNonTerminalParser `struct_declaration mkStructDeclaration
 
-def parseStructDeclarationList : String → Lean.Environment → Option String × StructDeclarationList := 
+def parseStructDeclarationList : String → Lean.Environment → Except ParseError StructDeclarationList := 
   mkNonTerminalParser `struct_declaration_list mkStructDeclarationList
 
-def parseStructDeclList : String → Lean.Environment → Option String × StructDeclList := 
+def parseStructDeclList : String → Lean.Environment → Except ParseError StructDeclList := 
   mkNonTerminalParser `struct_declarator_list mkStructDeclList
 
-def parseStructOrUnion : String → Lean.Environment → Option String × StructOrUnion := 
+def parseStructOrUnion : String → Lean.Environment → Except ParseError StructOrUnion := 
   mkNonTerminalParser `struct_or_union mkStructOrUnion
 
-def parseStructOrUnionSpec : String → Lean.Environment → Option String × StructOrUnionSpec := 
+def parseStructOrUnionSpec : String → Lean.Environment → Except ParseError StructOrUnionSpec := 
   mkNonTerminalParser `struct_or_union_specifier mkStructOrUnionSpec
 
-def parseTypeName : String → Lean.Environment → Option String × TypeName := 
+def parseTypeName : String → Lean.Environment → Except ParseError TypeName := 
   mkNonTerminalParser `type_name mkTypeName
 
-def parseTypeSpec : String → Lean.Environment → Option String × TypeSpec := 
+def parseTypeSpec : String → Lean.Environment → Except ParseError TypeSpec := 
   mkNonTerminalParser `type_specifier mkTypeSpec
 
-def parseExprStmt : String → Lean.Environment → Option String × ExprStmt := 
+def parseExprStmt : String → Lean.Environment → Except ParseError ExprStmt := 
   mkNonTerminalParser `expression_statement mkExprStmt
 
-def parseSelStmt : String → Lean.Environment → Option String × SelStmt := 
+def parseSelStmt : String → Lean.Environment → Except ParseError SelStmt := 
   mkNonTerminalParser `selection_statement mkSelStmt
 
-def parseIterStmt : String → Lean.Environment → Option String × IterStmt := 
+def parseIterStmt : String → Lean.Environment → Except ParseError IterStmt := 
   mkNonTerminalParser `iteration_statement mkIterStmt
 
-def parseJumpStmt : String → Lean.Environment → Option String × JumpStmt := 
+def parseJumpStmt : String → Lean.Environment → Except ParseError JumpStmt := 
   mkNonTerminalParser `jump_statement mkJumpStmt
 
-def parseLabelStmt : String → Lean.Environment → Option String × LabelStmt := 
+def parseLabelStmt : String → Lean.Environment → Except ParseError LabelStmt := 
   mkNonTerminalParser `labeled_statement mkLabelStmt
 
-def parseCompStmt : String → Lean.Environment → Option String × CompStmt := 
+def parseCompStmt : String → Lean.Environment → Except ParseError CompStmt := 
   mkNonTerminalParser `compound_statement mkCompStmt
 
-def parseStatement : String → Lean.Environment → Option String × Statement := 
+def parseStatement : String → Lean.Environment → Except ParseError Statement := 
   mkNonTerminalParser `statement mkStatement
 
-def parseStmtList : String → Lean.Environment → Option String × StmtList := 
+def parseStmtList : String → Lean.Environment → Except ParseError StmtList := 
   mkNonTerminalParser `statement_list mkStmtList
 
-def parseFuncDef : String → Lean.Environment → Option String × FuncDef := 
+def parseFuncDef : String → Lean.Environment → Except ParseError FuncDef := 
   mkNonTerminalParser `function_definition mkFuncDef
 
-def parseExternDecl : String → Lean.Environment → Option String × ExternDecl := 
+def parseExternDecl : String → Lean.Environment → Except ParseError ExternDecl := 
   mkNonTerminalParser `external_declaration mkExternDecl
 
-def parseTranslUnit : String → Lean.Environment → Option String × TranslUnit := 
+def parseTranslUnit : String → Lean.Environment → Except ParseError TranslUnit := 
   mkNonTerminalParser `translation_unit mkTranslUnit
 
 -- Parse the top-level nonterminal of our grammar.

--- a/CParser/Util.lean
+++ b/CParser/Util.lean
@@ -39,18 +39,20 @@ def removeCommentsLine : String → String :=
 def preprocess (lines : Array String ) : Array String :=
 lines.map (λ l => removeCommentsLine l)
 
-private def mkParseFun {α : Type} (syntaxcat : Name) (ntparser : Syntax → Except String α) :
+abbrev ParseError := String
+private def mkParseFun {α : Type} (syntaxcat : Name) (ntparser : Syntax → Except ParseError α) :
 String → Environment → Except String α := λ s env => do
   ntparser (← Parser.runParserCategory env syntaxcat s)
 
 -- Create a parser for a syntax category named `syntaxcat`, which uses `ntparser` to read a syntax node and produces a value α, or an error.
 -- This returns a function that given a string `s` and an environment `env`, tries to parse the string, and produces an error.
-def mkNonTerminalParser {α : Type} [Inhabited α] (syntaxcat : Name) (ntparser : Syntax → Except String α)
-(s : String) (env : Environment) : Option String × α :=
+def mkNonTerminalParser {α : Type} [Inhabited α] (syntaxcat : Name) (ntparser : Syntax → Except ParseError α)
+(s : String) (env : Environment) : Except String α :=
   let parseFun := mkParseFun syntaxcat ntparser
-  match parseFun s env with
-   | .error msg => (some msg, default)
-   | .ok    p   => (none, p)
+  parseFun s env
+  -- match parseFun s env with
+  --  | .error msg => (some msg, default)
+  --  | .ok    p   => (none, p)
 
 -- For regex matching
 inductive Regex where

--- a/Main.lean
+++ b/Main.lean
@@ -3,211 +3,84 @@ import CParser
 import CParser.AST
 import CParser.Parser
 
+open Lean
 open IO
 open IO.FS
 open System
 open AST
 
-inductive AnyNonterminal where
-  | AddExpr : AddExpr → AnyNonterminal
-  | AndExpr : AndExpr → AnyNonterminal
-  | ArgExprList : ArgExprList → AnyNonterminal
-  | AssmtExpr : AssmtExpr → AnyNonterminal
-  | AssmtOp : AssmtOp → AnyNonterminal
-  | CastExpr : CastExpr → AnyNonterminal
-  | CondExpr : CondExpr → AnyNonterminal
-  | EqExpr : EqExpr → AnyNonterminal
-  | Expr : Expression → AnyNonterminal
-  | IOrExpr : IOrExpr → AnyNonterminal
-  | LAndExpr : LAndExpr → AnyNonterminal
-  | LOrExpr : LOrExpr → AnyNonterminal
-  | MultExpr : MultExpr → AnyNonterminal
-  | PostfixExpr : PostfixExpr → AnyNonterminal
-  | PrimaryExpr : PrimaryExpr → AnyNonterminal
-  | RelExpr : RelExpr → AnyNonterminal
-  | ShiftExpr : ShiftExpr → AnyNonterminal
-  | UnaryExpr : UnaryExpr → AnyNonterminal
-  | UnaryOp : UnaryOp → AnyNonterminal
-  | XOrExpr : XOrExpr → AnyNonterminal
-  | AbstrDecl : AbstrDecl → AnyNonterminal
-  | ConstExpr : ConstantExpr → AnyNonterminal
-  | Declarator : Declarator → AnyNonterminal
-  | DirAbstrDecl : DirAbstrDecl → AnyNonterminal
-  | DirDecl : DirDecl → AnyNonterminal
-  | IdentList : IdentList → AnyNonterminal
-  | InitDecl : InitDecl → AnyNonterminal
-  | InitList : InitList → AnyNonterminal
-  | Initializer : Initializer → AnyNonterminal
-  | Pointer : Pointer → AnyNonterminal
-  | TypeQual : TypeQual → AnyNonterminal
-  | TypeQualList : TypeQualList → AnyNonterminal
-  | DeclList : DeclList → AnyNonterminal
-  | DeclSpec : DeclSpec → AnyNonterminal
-  | Declaration : Declaration → AnyNonterminal
-  | EnumList : EnumList → AnyNonterminal
-  | EnumSpec : EnumSpec → AnyNonterminal
-  | Enumerator : Enumerator → AnyNonterminal
-  | InitDeclList : InitDeclList → AnyNonterminal
-  | ParamDecl : ParamDecl → AnyNonterminal
-  | ParamList : ParamList → AnyNonterminal
-  | ParamTypeList : ParamTypeList → AnyNonterminal
-  | SpecQualList : SpecQualList → AnyNonterminal
-  | StorClassSpec : StorClassSpec → AnyNonterminal
-  | StructDecl : StructDecl → AnyNonterminal
-  | StructDeclList : StructDeclList → AnyNonterminal
-  | StructDeclaration : StructDeclaration → AnyNonterminal
-  | StructDeclarationList : StructDeclarationList → AnyNonterminal
-  | StructOrUnion : StructOrUnion → AnyNonterminal
-  | StructOrUnionSpec : StructOrUnionSpec → AnyNonterminal
-  | TypeName : TypeName → AnyNonterminal
-  | TypeSpec : TypeSpec → AnyNonterminal
-  | CompStmt : CompStmt → AnyNonterminal
-  | ExprStmt : ExprStmt → AnyNonterminal
-  | IterStmt : IterStmt → AnyNonterminal
-  | JumpStmt : JumpStmt → AnyNonterminal
-  | LabelStmt : LabelStmt → AnyNonterminal
-  | SelStmt : SelStmt → AnyNonterminal
-  | Statement : Statement → AnyNonterminal
-  | StmtList : StmtList → AnyNonterminal
-  | ExternDecl : ExternDecl → AnyNonterminal
-  | FuncDef : FuncDef → AnyNonterminal
-  | TranslUnit : TranslUnit → AnyNonterminal
+abbrev ParseOutput := String
 
-instance : ToString AnyNonterminal where toString := fun nont => match nont with
-  | .AddExpr x => toString x
-  | .AndExpr x => toString x
-  | .ArgExprList x => toString x
-  | .AssmtExpr x => toString x
-  | .AssmtOp x => toString x
-  | .CastExpr x => toString x
-  | .CondExpr x => toString x
-  | .EqExpr x => toString x
-  | .Expr x => toString x
-  | .IOrExpr x => toString x
-  | .LAndExpr x => toString x
-  | .LOrExpr x => toString x
-  | .MultExpr x => toString x
-  | .PostfixExpr x => toString x
-  | .PrimaryExpr x => toString x
-  | .RelExpr x => toString x
-  | .ShiftExpr x => toString x
-  | .UnaryExpr x => toString x
-  | .UnaryOp x => toString x
-  | .XOrExpr x => toString x
-  | .AbstrDecl x => toString x
-  | .ConstExpr x => toString x
-  | .Declarator x => toString x
-  | .DirAbstrDecl x => toString x
-  | .DirDecl x => toString x
-  | .IdentList x => toString x
-  | .InitDecl x => toString x
-  | .InitList x => toString x
-  | .Initializer x => toString x
-  | .Pointer x => toString x
-  | .TypeQual x => toString x
-  | .TypeQualList x => toString x
-  | .DeclList x => toString x
-  | .DeclSpec x => toString x
-  | .Declaration x => toString x
-  | .EnumList x => toString x
-  | .EnumSpec x => toString x
-  | .Enumerator x => toString x
-  | .InitDeclList x => toString x
-  | .ParamDecl x => toString x
-  | .ParamList x => toString x
-  | .ParamTypeList x => toString x
-  | .SpecQualList x => toString x
-  | .StorClassSpec x => toString x
-  | .StructDecl x => toString x
-  | .StructDeclList x => toString x
-  | .StructDeclaration x => toString x
-  | .StructDeclarationList x => toString x
-  | .StructOrUnion x => toString x
-  | .StructOrUnionSpec x => toString x
-  | .TypeName x => toString x
-  | .TypeSpec x => toString x
-  | .CompStmt x => toString x
-  | .ExprStmt x => toString x
-  | .IterStmt x => toString x
-  | .JumpStmt x => toString x
-  | .LabelStmt x => toString x
-  | .SelStmt x => toString x
-  | .Statement x => toString x
-  | .StmtList x => toString x
-  | .ExternDecl x => toString x
-  | .FuncDef x => toString x
-  | .TranslUnit x => toString x
-
-abbrev Checker := (String → Lean.Environment → Option String × AnyNonterminal)
+abbrev Checker := (String → Lean.Environment → Except ParseError ParseOutput)
 
 def directory_checker_map : List (FilePath × Checker) := 
- [(FilePath.mk "./Tests/GroupOne/AddExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.AddExpr y)) $ parseAddExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/AndExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.AndExpr y)) $ parseAndExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/ArgExprList", fun str env => ((fun (x, y) => (x, AnyNonterminal.ArgExprList y)) $ parseArgExprList str env))
- ,(FilePath.mk "./Tests/GroupOne/AssmtExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.AssmtExpr y)) $ parseAssmtExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/AssmtOp", fun str env => ((fun (x, y) => (x, AnyNonterminal.AssmtOp y)) $ parseAssmtOperator str env))
- ,(FilePath.mk "./Tests/GroupOne/CastExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.CastExpr y)) $ parseCastExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/CondExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.CondExpr y)) $ parseCondExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/EqExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.EqExpr y)) $ parseEqExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/Expr", fun str env => ((fun (x, y) => (x, AnyNonterminal.Expr y)) $ parseExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/IOrExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.IOrExpr y)) $ parseIOrExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/LAndExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.LAndExpr y)) $ parseLAndExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/LOrExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.LOrExpr y)) $ parseLOrExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/MultExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.MultExpr y)) $ parseMultExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/PostfixExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.PostfixExpr y)) $ parsePostfixExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/PrimaryExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.PrimaryExpr y)) $ parsePrimaryExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/RelExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.RelExpr y)) $ parseRelExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/ShiftExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.ShiftExpr y)) $ parseShiftExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/UnaryExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.UnaryExpr y)) $ parseUnaryExpression str env))
- ,(FilePath.mk "./Tests/GroupOne/UnaryOp", fun str env => ((fun (x, y) => (x, AnyNonterminal.UnaryOp y)) $ parseUnaryOperator str env))
- ,(FilePath.mk "./Tests/GroupOne/XOrExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.XOrExpr y)) $ parseXOrExpression str env))
+ [(FilePath.mk "./Tests/GroupOne/AddExpr", fun str env => (Functor.map ToString.toString $ parseAddExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/AndExpr", fun str env => (Functor.map ToString.toString $ parseAndExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/ArgExprList", fun str env => (Functor.map ToString.toString $ parseArgExprList str env))
+ ,(FilePath.mk "./Tests/GroupOne/AssmtExpr", fun str env => (Functor.map ToString.toString $ parseAssmtExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/AssmtOp", fun str env => (Functor.map ToString.toString $ parseAssmtOperator str env))
+ ,(FilePath.mk "./Tests/GroupOne/CastExpr", fun str env => (Functor.map ToString.toString $ parseCastExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/CondExpr", fun str env => (Functor.map ToString.toString $ parseCondExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/EqExpr", fun str env => (Functor.map ToString.toString $ parseEqExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/Expr", fun str env => (Functor.map ToString.toString $ parseExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/IOrExpr", fun str env => (Functor.map ToString.toString $ parseIOrExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/LAndExpr", fun str env => (Functor.map ToString.toString $ parseLAndExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/LOrExpr", fun str env => (Functor.map ToString.toString $ parseLOrExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/MultExpr", fun str env => (Functor.map ToString.toString $ parseMultExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/PostfixExpr", fun str env => (Functor.map ToString.toString $ parsePostfixExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/PrimaryExpr", fun str env => (Functor.map ToString.toString $ parsePrimaryExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/RelExpr", fun str env => (Functor.map ToString.toString $ parseRelExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/ShiftExpr", fun str env => (Functor.map ToString.toString $ parseShiftExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/UnaryExpr", fun str env => (Functor.map ToString.toString $ parseUnaryExpression str env))
+ ,(FilePath.mk "./Tests/GroupOne/UnaryOp", fun str env => (Functor.map ToString.toString $ parseUnaryOperator str env))
+ ,(FilePath.mk "./Tests/GroupOne/XOrExpr", fun str env => (Functor.map ToString.toString $ parseXOrExpression str env))
+ ]  ++
+ [(FilePath.mk "./Tests/GroupTwo/AbstrDecl", fun str env => (Functor.map ToString.toString $ parseAbstrDecl str env))
+ ,(FilePath.mk "./Tests/GroupTwo/ConstExpr", fun str env => (Functor.map ToString.toString $ parseConstantExpression str env))
+ ,(FilePath.mk "./Tests/GroupTwo/Declarator", fun str env => (Functor.map ToString.toString $ parseDeclarator str env))
+ ,(FilePath.mk "./Tests/GroupTwo/DirAbstrDecl", fun str env => (Functor.map ToString.toString $ parseDirAbstrDecl str env))
+ ,(FilePath.mk "./Tests/GroupTwo/DirDecl", fun str env => (Functor.map ToString.toString $ parseDirDecl str env))
+ ,(FilePath.mk "./Tests/GroupTwo/IdentList", fun str env => (Functor.map ToString.toString $ parseIdentList str env))
+ ,(FilePath.mk "./Tests/GroupTwo/InitDecl", fun str env => (Functor.map ToString.toString $ parseInitDecl str env))
+ ,(FilePath.mk "./Tests/GroupTwo/InitList", fun str env => (Functor.map ToString.toString $ parseInitList str env))
+ ,(FilePath.mk "./Tests/GroupTwo/Initializer", fun str env => (Functor.map ToString.toString $ parseInitializer str env))
+ ,(FilePath.mk "./Tests/GroupTwo/Pointer", fun str env => (Functor.map ToString.toString $ parsePointer str env))
+ ,(FilePath.mk "./Tests/GroupTwo/TypeQual", fun str env => (Functor.map ToString.toString $ parseTypeQual str env))
+ ,(FilePath.mk "./Tests/GroupTwo/TypeQualList", fun str env => (Functor.map ToString.toString $ parseTypeQualList str env))
  ] ++
- [(FilePath.mk "./Tests/GroupTwo/AbstrDecl", fun str env => ((fun (x, y) => (x, AnyNonterminal.AbstrDecl y)) $ parseAbstrDecl str env))
- ,(FilePath.mk "./Tests/GroupTwo/ConstExpr", fun str env => ((fun (x, y) => (x, AnyNonterminal.ConstExpr y)) $ parseConstantExpression str env))
- ,(FilePath.mk "./Tests/GroupTwo/Declarator", fun str env => ((fun (x, y) => (x, AnyNonterminal.Declarator y)) $ parseDeclarator str env))
- ,(FilePath.mk "./Tests/GroupTwo/DirAbstrDecl", fun str env => ((fun (x, y) => (x, AnyNonterminal.DirAbstrDecl y)) $ parseDirAbstrDecl str env))
- ,(FilePath.mk "./Tests/GroupTwo/DirDecl", fun str env => ((fun (x, y) => (x, AnyNonterminal.DirDecl y)) $ parseDirDecl str env))
- ,(FilePath.mk "./Tests/GroupTwo/IdentList", fun str env => ((fun (x, y) => (x, AnyNonterminal.IdentList y)) $ parseIdentList str env))
- ,(FilePath.mk "./Tests/GroupTwo/InitDecl", fun str env => ((fun (x, y) => (x, AnyNonterminal.InitDecl y)) $ parseInitDecl str env))
- ,(FilePath.mk "./Tests/GroupTwo/InitList", fun str env => ((fun (x, y) => (x, AnyNonterminal.InitList y)) $ parseInitList str env))
- ,(FilePath.mk "./Tests/GroupTwo/Initializer", fun str env => ((fun (x, y) => (x, AnyNonterminal.Initializer y)) $ parseInitializer str env))
- ,(FilePath.mk "./Tests/GroupTwo/Pointer", fun str env => ((fun (x, y) => (x, AnyNonterminal.Pointer y)) $ parsePointer str env))
- ,(FilePath.mk "./Tests/GroupTwo/TypeQual", fun str env => ((fun (x, y) => (x, AnyNonterminal.TypeQual y)) $ parseTypeQual str env))
- ,(FilePath.mk "./Tests/GroupTwo/TypeQualList", fun str env => ((fun (x, y) => (x, AnyNonterminal.TypeQualList y)) $ parseTypeQualList str env))
+ [(FilePath.mk "./Tests/GroupThree/Declaration", fun str env => (Functor.map ToString.toString $ parseDeclaration str env))
+ ,(FilePath.mk "./Tests/GroupThree/DeclList", fun str env => (Functor.map ToString.toString $ parseDeclList str env))
+ ,(FilePath.mk "./Tests/GroupThree/DeclSpec", fun str env => (Functor.map ToString.toString $ parseDeclSpec str env))
+ ,(FilePath.mk "./Tests/GroupThree/Enumerator", fun str env => (Functor.map ToString.toString $ parseEnumerator str env))
+ ,(FilePath.mk "./Tests/GroupThree/EnumList", fun str env => (Functor.map ToString.toString $ parseEnumList str env))
+ ,(FilePath.mk "./Tests/GroupThree/EnumSpec", fun str env => (Functor.map ToString.toString $ parseEnumSpec str env))
+ ,(FilePath.mk "./Tests/GroupThree/InitDeclList", fun str env => (Functor.map ToString.toString $ parseInitDeclList str env))
+ ,(FilePath.mk "./Tests/GroupThree/ParamDecl", fun str env => (Functor.map ToString.toString $ parseParamDecl str env))
+ ,(FilePath.mk "./Tests/GroupThree/ParamList", fun str env => (Functor.map ToString.toString $ parseParamList str env))
+ ,(FilePath.mk "./Tests/GroupThree/ParamTypeList", fun str env => (Functor.map ToString.toString $ parseParamTypeList str env))
+ ,(FilePath.mk "./Tests/GroupThree/SpecQualList", fun str env => (Functor.map ToString.toString $ parseSpecQualList str env))
+ ,(FilePath.mk "./Tests/GroupThree/StorClassSpec", fun str env => (Functor.map ToString.toString $ parseStorClassSpec str env))
+ ,(FilePath.mk "./Tests/GroupThree/StructDecl", fun str env => (Functor.map ToString.toString $ parseStructDecl str env))
+ ,(FilePath.mk "./Tests/GroupThree/StructDeclaration", fun str env => (Functor.map ToString.toString $ parseStructDeclaration str env))
+ ,(FilePath.mk "./Tests/GroupThree/StructDeclarationList", fun str env => (Functor.map ToString.toString $ parseStructDeclarationList str env))
+ ,(FilePath.mk "./Tests/GroupThree/StructDeclList", fun str env => (Functor.map ToString.toString $ parseStructDeclList str env))
+ ,(FilePath.mk "./Tests/GroupThree/StructOrUnion", fun str env => (Functor.map ToString.toString $ parseStructOrUnion str env))
+ ,(FilePath.mk "./Tests/GroupThree/StructOrUnionSpec", fun str env => (Functor.map ToString.toString $ parseStructOrUnionSpec str env))
+ ,(FilePath.mk "./Tests/GroupThree/TypeName", fun str env => (Functor.map ToString.toString $ parseTypeName str env))
+ ,(FilePath.mk "./Tests/GroupThree/TypeSpec", fun str env => (Functor.map ToString.toString $ parseTypeSpec str env))
  ] ++
- [(FilePath.mk "./Tests/GroupThree/Declaration", fun str env => ((fun (x, y) => (x, AnyNonterminal.Declaration y)) $ parseDeclaration str env))
- ,(FilePath.mk "./Tests/GroupThree/DeclList", fun str env => ((fun (x, y) => (x, AnyNonterminal.DeclList y)) $ parseDeclList str env))
- ,(FilePath.mk "./Tests/GroupThree/DeclSpec", fun str env => ((fun (x, y) => (x, AnyNonterminal.DeclSpec y)) $ parseDeclSpec str env))
- ,(FilePath.mk "./Tests/GroupThree/Enumerator", fun str env => ((fun (x, y) => (x, AnyNonterminal.Enumerator y)) $ parseEnumerator str env))
- ,(FilePath.mk "./Tests/GroupThree/EnumList", fun str env => ((fun (x, y) => (x, AnyNonterminal.EnumList y)) $ parseEnumList str env))
- ,(FilePath.mk "./Tests/GroupThree/EnumSpec", fun str env => ((fun (x, y) => (x, AnyNonterminal.EnumSpec y)) $ parseEnumSpec str env))
- ,(FilePath.mk "./Tests/GroupThree/InitDeclList", fun str env => ((fun (x, y) => (x, AnyNonterminal.InitDeclList y)) $ parseInitDeclList str env))
- ,(FilePath.mk "./Tests/GroupThree/ParamDecl", fun str env => ((fun (x, y) => (x, AnyNonterminal.ParamDecl y)) $ parseParamDecl str env))
- ,(FilePath.mk "./Tests/GroupThree/ParamList", fun str env => ((fun (x, y) => (x, AnyNonterminal.ParamList y)) $ parseParamList str env))
- ,(FilePath.mk "./Tests/GroupThree/ParamTypeList", fun str env => ((fun (x, y) => (x, AnyNonterminal.ParamTypeList y)) $ parseParamTypeList str env))
- ,(FilePath.mk "./Tests/GroupThree/SpecQualList", fun str env => ((fun (x, y) => (x, AnyNonterminal.SpecQualList y)) $ parseSpecQualList str env))
- ,(FilePath.mk "./Tests/GroupThree/StorClassSpec", fun str env => ((fun (x, y) => (x, AnyNonterminal.StorClassSpec y)) $ parseStorClassSpec str env))
- ,(FilePath.mk "./Tests/GroupThree/StructDecl", fun str env => ((fun (x, y) => (x, AnyNonterminal.StructDecl y)) $ parseStructDecl str env))
- ,(FilePath.mk "./Tests/GroupThree/StructDeclaration", fun str env => ((fun (x, y) => (x, AnyNonterminal.StructDeclaration y)) $ parseStructDeclaration str env))
- ,(FilePath.mk "./Tests/GroupThree/StructDeclarationList", fun str env => ((fun (x, y) => (x, AnyNonterminal.StructDeclarationList y)) $ parseStructDeclarationList str env))
- ,(FilePath.mk "./Tests/GroupThree/StructDeclList", fun str env => ((fun (x, y) => (x, AnyNonterminal.StructDeclList y)) $ parseStructDeclList str env))
- ,(FilePath.mk "./Tests/GroupThree/StructOrUnion", fun str env => ((fun (x, y) => (x, AnyNonterminal.StructOrUnion y)) $ parseStructOrUnion str env))
- ,(FilePath.mk "./Tests/GroupThree/StructOrUnionSpec", fun str env => ((fun (x, y) => (x, AnyNonterminal.StructOrUnionSpec y)) $ parseStructOrUnionSpec str env))
- ,(FilePath.mk "./Tests/GroupThree/TypeName", fun str env => ((fun (x, y) => (x, AnyNonterminal.TypeName y)) $ parseTypeName str env))
- ,(FilePath.mk "./Tests/GroupThree/TypeSpec", fun str env => ((fun (x, y) => (x, AnyNonterminal.TypeSpec y)) $ parseTypeSpec str env))
+ [(FilePath.mk "./Tests/GroupFour/CompStmt", fun str env => (Functor.map ToString.toString $ parseCompStmt str env))
+ ,(FilePath.mk "./Tests/GroupFour/ExprStmt", fun str env => (Functor.map ToString.toString $ parseExprStmt str env))
+ ,(FilePath.mk "./Tests/GroupFour/IterStmt", fun str env => (Functor.map ToString.toString $ parseIterStmt str env))
+ ,(FilePath.mk "./Tests/GroupFour/JumpStmt", fun str env => (Functor.map ToString.toString $ parseJumpStmt str env))
+ ,(FilePath.mk "./Tests/GroupFour/LabelStmt", fun str env => (Functor.map ToString.toString $ parseLabelStmt str env))
+ ,(FilePath.mk "./Tests/GroupFour/SelStmt", fun str env => (Functor.map ToString.toString $ parseSelStmt str env))
+ ,(FilePath.mk "./Tests/GroupFour/Statement", fun str env => (Functor.map ToString.toString $ parseStatement str env))
+ ,(FilePath.mk "./Tests/GroupFour/StmtList", fun str env => (Functor.map ToString.toString $ parseStmtList str env))
  ] ++
- [(FilePath.mk "./Tests/GroupFour/CompStmt", fun str env => ((fun (x, y) => (x, AnyNonterminal.CompStmt y)) $ parseCompStmt str env))
- ,(FilePath.mk "./Tests/GroupFour/ExprStmt", fun str env => ((fun (x, y) => (x, AnyNonterminal.ExprStmt y)) $ parseExprStmt str env))
- ,(FilePath.mk "./Tests/GroupFour/IterStmt", fun str env => ((fun (x, y) => (x, AnyNonterminal.IterStmt y)) $ parseIterStmt str env))
- ,(FilePath.mk "./Tests/GroupFour/JumpStmt", fun str env => ((fun (x, y) => (x, AnyNonterminal.JumpStmt y)) $ parseJumpStmt str env))
- ,(FilePath.mk "./Tests/GroupFour/LabelStmt", fun str env => ((fun (x, y) => (x, AnyNonterminal.LabelStmt y)) $ parseLabelStmt str env))
- ,(FilePath.mk "./Tests/GroupFour/SelStmt", fun str env => ((fun (x, y) => (x, AnyNonterminal.SelStmt y)) $ parseSelStmt str env))
- ,(FilePath.mk "./Tests/GroupFour/Statement", fun str env => ((fun (x, y) => (x, AnyNonterminal.Statement y)) $ parseStatement str env))
- ,(FilePath.mk "./Tests/GroupFour/StmtList", fun str env => ((fun (x, y) => (x, AnyNonterminal.StmtList y)) $ parseStmtList str env))
- ] ++
- [(FilePath.mk "./Tests/GroupFive/ExternDecl", fun str env => ((fun (x, y) => (x, AnyNonterminal.ExternDecl y)) $ parseExternDecl str env))
- ,(FilePath.mk "./Tests/GroupFive/FuncDef", fun str env => ((fun (x, y) => (x, AnyNonterminal.FuncDef y)) $ parseFuncDef str env))
- ,(FilePath.mk "./Tests/GroupFive/TranslUnit", fun str env => ((fun (x, y) => (x, AnyNonterminal.TranslUnit y)) $ parseTranslUnit str env))
+ [(FilePath.mk "./Tests/GroupFive/ExternDecl", fun str env => (Functor.map ToString.toString $ parseExternDecl str env))
+ ,(FilePath.mk "./Tests/GroupFive/FuncDef", fun str env => (Functor.map ToString.toString $ parseFuncDef str env))
+ ,(FilePath.mk "./Tests/GroupFive/TranslUnit", fun str env => (Functor.map ToString.toString $ parseTranslUnit str env))
  ]
 
 inductive TestResult
@@ -232,11 +105,11 @@ def checkFileParse (env: Lean.Environment)
   let fileStr := preprocessed.foldl (λ s₁ s₂ => s₁ ++ "\n" ++ s₂) ""
   -- let pipeline := Lean.quote [file]
   match checker fileStr env with
-    | (some msg, _) => do 
-       IO.println $ s!"{filepath}, error, {msg}"
+    | .error e => do 
+       IO.println $ s!"{filepath}, error, {e}"
        return TestResult.Failure
-    | (none, ast) => do
-      IO.println $ s!"{filepath}, ok,\nAST:\n" ++ toString ast
+    | .ok ast => do
+      IO.println $ s!"{filepath}, ok,\nAST:\n" ++ ast
       return TestResult.Success
 
 def runTestHarness: IO UInt32 := do


### PR DESCRIPTION
instad of using `Option String \times String`, which has unclear
semantics, use `Except ParseError ParseOutput` to clearly state
what the function is supposed to do.

Also, see that we introducec the indirection of the type `AnyNonterminal.*`,
to call `toString` on it. Avoid this indirection by immediately calling
`toString` on the nonterminal we produce, thereby eliminating the need
for `AnyNonterminal`.

In general, if we introduce an inductive only to dispatch on a
typeclass, it is often possible to directly hold a reference to the
typeclass itself: https://softwareengineering.stackexchange.com/a/311833